### PR TITLE
Fix: Update .readthedocs.yaml for pyproject.toml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,5 +21,7 @@ sphinx:
 
 python:
    install:
-   - requirements: requirements.txt
-   - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
The Read the Docs build was failing because the .readthedocs.yaml file was configured to install dependencies from `requirements.txt` and `docs/requirements.txt`, which no longer exist.

This commit updates the .readthedocs.yaml configuration to install dependencies from `pyproject.toml` using the `docs` extra. This aligns the documentation build process with the project's current dependency management strategy.