### PR TITLE
Add opt-in tol-based early stopping to Estimator.estimate()

### DIFF
--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -152,7 +152,9 @@ class CliqueVector:
     tables = {cl: self.project(cl, log=log) for cl in cliques}
     return CliqueVector(self.domain, cliques, tables)
 
-  def normalize(self, total: float = 1, log: bool = True) -> CliqueVector:
+  def normalize(
+      self, total: jax.Array | float = 1, log: bool = True
+  ) -> CliqueVector:
     """Normalizes each factor within the CliqueVector."""
     return jax.tree.map(
         lambda f: f.normalize(total, log),

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -109,6 +109,10 @@ class Estimator(ABC):
     """
     return state[0]
 
+  def _loss_value(self, state, loss_fn, known_total, constraints=()):  # pylint: disable=unused-argument
+    """Current objective value for ``tol`` early stopping, or None."""
+    return getattr(state, "loss", None)
+
   def _oracle(self, cliques, domain, constraints=()):
     """Return the marginal oracle, falling back to ``default_oracle``."""
     oracle = self.marginal_oracle or marginal_oracles.default_oracle(
@@ -129,6 +133,8 @@ class Estimator(ABC):
       iters: int = 1000,
       callback_fn: Callable | None = None,
       warm_start: Model | None = None,
+      tol: float | None = None,
+      patience: int = 2,
       **kwargs: Any,
   ) -> Model:
     """Estimate a Model from noisy marginal measurements.
@@ -137,6 +143,10 @@ class Estimator(ABC):
     previously estimated model instead of from scratch.  For potential-based
     estimators the model's potentials are expanded to cover any new cliques;
     for MixtureOfProducts the model is used directly.
+
+    If ``tol`` is set, optimization stops early once the relative loss
+    improvement over a callback block stays at or below ``tol`` for
+    ``patience`` consecutive blocks (default: run the full ``iters``).
     """
     constraints = tuple(constraints)
     if isinstance(loss_fn, list):
@@ -178,10 +188,21 @@ class Estimator(ABC):
     )
     # De-alias so that donate_argnames in _multi_step is safe.
     state = jax.tree.map(jnp.copy, state)
+    prev_loss, stalls = np.inf, 0
     for _ in range(math.ceil(iters / CALLBACK_EVERY)):
       state = self._multi_step(state, loss_fn, known_total, constraints)
       if callback_fn is not None:
         callback_fn(self._callback_value(state, known_total, constraints))
+      if tol is not None:
+        loss = self._loss_value(state, loss_fn, known_total, constraints)
+        if loss is None:
+          raise ValueError(f"{type(self).__name__} does not support tol.")
+        loss = float(loss)
+        converged = prev_loss - loss <= tol * max(abs(loss), 1.0)
+        stalls = stalls + 1 if converged else 0
+        prev_loss = loss
+        if stalls >= patience:
+          break
     return self._finalize(state, known_total, constraints=constraints)
 
   @jax.jit(static_argnames=["self"], donate_argnames=["state"])
@@ -710,6 +731,10 @@ class LBFGS(Estimator):
     )
     return marginal_oracle(state.potentials, known_total)
 
+  def _loss_value(self, state, loss_fn, known_total, constraints=()):
+    # optax.lbfgs stores the latest objective value in its state.
+    return optax.tree_utils.tree_get(state.opt_state, "value")
+
   def _finalize(self, state, known_total, constraints=()):
     marginal_oracle = self._oracle(
         state.potentials.cliques,
@@ -884,6 +909,10 @@ class UniversalAcceleratedMethod(Estimator):
   def _callback_value(self, state, known_total, constraints=()):
     # Scale back to N-simplex for user-facing callbacks.
     return state.x * known_total
+
+  def _loss_value(self, state, loss_fn, known_total, constraints=()):
+    # State tracks no loss; recompute on the N-scaled iterate.
+    return loss_fn(state.x * known_total)
 
   def _finalize(self, state, known_total, constraints=()):
     # Scale back to N-simplex and recover potentials via MLE.

--- a/src/mbi/factor.py
+++ b/src/mbi/factor.py
@@ -162,7 +162,9 @@ class Factor:
     """Applies element-wise logarithm (jnp.log) to the factor's values."""
     return Factor(self.domain, jnp.log(self.values))
 
-  def normalize(self, total: float = 1.0, log: bool = False) -> Factor:
+  def normalize(
+      self, total: jax.Array | float = 1.0, log: bool = False
+  ) -> Factor:
     """Normalizes the factor so its values sum to `total` (or log-normalize)."""
     if log:
       return self + jnp.log(total) - self.logsumexp()

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -62,7 +62,7 @@ class MarginalOracle(Protocol):
   def __call__(
       self,
       potentials: CliqueVector,
-      total: float = 1.0,
+      total: jax.Array | float = 1.0,
       *,
       constraints: Sequence[Constraint] = (),
   ) -> CliqueVector:
@@ -230,7 +230,7 @@ def _fold_constraints(
 @jax.jit(static_argnames=["jtree", "return_messages"])
 def message_passing_hugin(
     potentials: CliqueVector,
-    total: float = 1.0,
+    total: jax.Array | float = 1.0,
     jtree: nx.Graph | None = None,
     *,
     constraints: Sequence[Constraint] = (),
@@ -290,7 +290,7 @@ def message_passing_hugin(
 @jax.jit(static_argnames=["jtree", "return_messages"])
 def message_passing_shafer_shenoy(
     potentials: CliqueVector,
-    total: float = 1.0,
+    total: jax.Array | float = 1.0,
     jtree: nx.Graph | None = None,
     *,
     constraints: Sequence[Constraint] = (),
@@ -354,7 +354,7 @@ def message_passing_shafer_shenoy(
 @jax.jit(static_argnames=["jtree", "contraction", "return_messages"])
 def message_passing_implicit(
     potentials: CliqueVector,
-    total: float = 1.0,
+    total: jax.Array | float = 1.0,
     jtree: nx.Graph | None = None,
     *,
     constraints: Sequence[Constraint] = (),
@@ -550,7 +550,7 @@ def default_oracle(
 
 def brute_force_marginals(
     potentials: CliqueVector,
-    total: float = 1,
+    total: jax.Array | float = 1,
     *,
     constraints: Sequence[Constraint] = (),
 ) -> CliqueVector:
@@ -577,7 +577,7 @@ def brute_force_marginals(
 
 def einsum_marginals(
     potentials: CliqueVector,
-    total: float = 1,
+    total: jax.Array | float = 1,
     einsum_fn: Callable = jnp.einsum,
     *,
     constraints: Sequence[Constraint] = (),
@@ -622,7 +622,7 @@ def einsum_marginals(
 def variable_elimination(
     potentials: CliqueVector,
     clique: Clique,
-    total: float = 1,
+    total: jax.Array | float = 1,
     evidence: dict[Attribute, int] | None = None,
     *,
     constraints: Sequence[Constraint] = (),

--- a/test/test_estimation.py
+++ b/test/test_estimation.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 import unittest
 
 import numpy as np
@@ -173,6 +174,71 @@ class TestEstimation(unittest.TestCase):
       expected = mu.project(cl).datavector()
       actual = model.project(cl).datavector()
       np.testing.assert_allclose(actual, expected, atol=100 / total)
+
+  def test_tol_none_runs_all_iters(self):
+    # tol=None runs the full budget: one callback per CALLBACK_EVERY block.
+    cliques = [("a", "b"), ("b", "c"), ("c", "d")]
+    loss_fn = marginal_loss.from_linear_measurements(
+        fake_measurements(cliques), _DOMAIN
+    )
+    calls = []
+    estimation.MirrorDescent().estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=200,
+        callback_fn=lambda _: calls.append(1),
+        tol=None,
+    )
+    self.assertEqual(len(calls), math.ceil(200 / estimation.CALLBACK_EVERY))
+
+  @parameterized.expand([estimation.MirrorDescent, estimation.LBFGS])
+  def test_tol_stops_early(self, estimator_cls):
+    # Monotone methods plateau and stop before the budget, still accurate.
+    measurements = fake_measurements([("a", "b"), ("b", "c"), ("c", "d")])
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+    calls = []
+    model = estimator_cls().estimate(
+        _DOMAIN,
+        loss_fn,
+        known_total=1.0,
+        iters=5000,
+        callback_fn=lambda _: calls.append(1),
+        tol=1e-6,
+    )
+    self.assertLess(len(calls), math.ceil(5000 / estimation.CALLBACK_EVERY))
+    for M in measurements:
+      actual = model.project(M.clique).datavector()
+      np.testing.assert_allclose(actual, M.noisy_measurement, atol=1e-2)
+
+  @parameterized.expand([
+      estimation.MirrorDescent,
+      estimation.DualAveraging,
+      estimation.InteriorGradient,
+      estimation.LBFGS,
+      estimation.UniversalAcceleratedMethod,
+  ])
+  def test_tol_supported_by_all_estimators(self, estimator_cls):
+    measurements = fake_measurements([("a", "b"), ("b", "c"), ("c", "d")])
+    loss_fn = marginal_loss.from_linear_measurements(measurements, _DOMAIN)
+    model = estimator_cls().estimate(
+        _DOMAIN, loss_fn, known_total=1.0, iters=500, tol=1e-6
+    )
+    for M in measurements:
+      actual = model.project(M.clique).datavector()
+      self.assertTrue(np.all(np.isfinite(actual)))
+
+  def test_tol_unsupported_estimator_raises(self):
+    class _NoLoss(estimation.MirrorDescent):
+
+      def _loss_value(self, state, loss_fn, known_total, constraints=()):
+        return None
+
+    loss_fn = marginal_loss.from_linear_measurements(
+        fake_measurements([("a", "b"), ("b", "c")]), _DOMAIN
+    )
+    with self.assertRaises(ValueError):
+      _NoLoss().estimate(_DOMAIN, loss_fn, known_total=1.0, iters=100, tol=1e-6)
 
   def test_precompile(self):
     """precompile() should complete without error."""


### PR DESCRIPTION
## Summary

Adds an optional, **default-off** `tol` early-termination criterion (plus a `patience` knob) to the shared `Estimator.estimate()` loop, addressing the request to let optimizers stop once convergence is reached to some tolerance.

The criterion is **relative loss improvement** over a callback block:
stop when `prev_loss - loss <= tol * max(|prev_loss|, 1.0)` for `patience`
consecutive blocks. `tol=None` (the default) preserves the exact previous
behavior.

## Why this design

- **Cheap & uniform.** The check runs at `CALLBACK_EVERY` granularity and reuses the loss scalar every estimator state already carries, so there's no new per-step host sync and it lives in **one place** in the base class.
- **Block granularity helps the non-monotone methods.** Comparing loss across 50-step blocks smooths per-step oscillation, so a plateau is more meaningful than a per-step delta; `patience` (default 2) further guards against premature stops.

## Soundness

- **Sound** convergence signal for the monotone methods: `MirrorDescent` (Armijo line search) and `LBFGS` (zoom line search).
- **Heuristic** for the non-monotone accelerated methods (`DualAveraging`, `InteriorGradient`, `UniversalAcceleratedMethod`) — documented as such. Off by default, so reproducibility is unaffected.

## Implementation

- New overridable `_loss_value(state, loss_fn, known_total, constraints)` hook returning the current objective:
  - default: `state.loss` (MirrorDescent / DualAveraging / InteriorGradient),
  - `LBFGS`: reads the value stored in the optax L-BFGS state,
  - `UniversalAcceleratedMethod`: recomputes on the N-scaled iterate (its state tracks no loss).
- Passing `tol` to an estimator that exposes no loss raises `ValueError` rather than silently no-op'ing.

## Tests

- `tol=None` runs the full iteration budget (no early stop).
- Monotone methods stop early while remaining accurate.
- All five estimators accept `tol` and return finite models.
- An estimator exposing no loss raises `ValueError`.

All of `test_estimation.py`, `test_callbacks.py`, `test_precompile.py` pass locally (88 passed).