### PR TITLE
Make precompile functions return a RobustFuture

### DIFF
--- a/src/mbi/_future.py
+++ b/src/mbi/_future.py
@@ -1,29 +1,34 @@
 import concurrent.futures
 import logging
 
+
 class RobustFuture(concurrent.futures.Future):
-    """A Future that intercepts and logs exceptions to prevent crashing downstream callers.
-    
-    If the wrapped task fails, this future resolves to ``None`` and logs the error,
-    avoiding an exception when `.result()` is called.
-    """
-    def __init__(self, wrapped_future: concurrent.futures.Future):
-        super().__init__()
-        self._wrapped_future = wrapped_future
+  """A Future that intercepts and logs exceptions to prevent crashing downstream callers.
 
-        def callback(f):
-            try:
-                self.set_result(f.result())
-            except Exception as e:
-                logging.info("Background precompilation failed (fallback to JIT at runtime): %s", e)
-                # Resolve to None without throwing an exception.
-                self.set_result(None)
+  If the wrapped task fails, this future resolves to ``None`` and logs the error,
+  avoiding an exception when `.result()` is called.
+  """
 
-        self._wrapped_future.add_done_callback(callback)
+  def __init__(self, wrapped_future: concurrent.futures.Future):
+    super().__init__()
+    self._wrapped_future = wrapped_future
 
-    def cancel(self):
-        """Cancel the wrapped future."""
-        # We must cancel the inner future, and depending on success, cancel ourselves.
-        if self._wrapped_future.cancel():
-            return super().cancel()
-        return False
+    def callback(f):
+      try:
+        self.set_result(f.result())
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        logging.info(
+            "Background precompilation failed (fallback to JIT at runtime): %s",
+            e,
+        )
+        # Resolve to None without throwing an exception.
+        self.set_result(None)
+
+    self._wrapped_future.add_done_callback(callback)
+
+  def cancel(self):
+    """Cancel the wrapped future."""
+    # We must cancel the inner future, and depending on success, cancel ourselves.
+    if self._wrapped_future.cancel():
+      return super().cancel()
+    return False

--- a/src/mbi/_future.py
+++ b/src/mbi/_future.py
@@ -1,0 +1,29 @@
+import concurrent.futures
+import logging
+
+class RobustFuture(concurrent.futures.Future):
+    """A Future that intercepts and logs exceptions to prevent crashing downstream callers.
+    
+    If the wrapped task fails, this future resolves to ``None`` and logs the error,
+    avoiding an exception when `.result()` is called.
+    """
+    def __init__(self, wrapped_future: concurrent.futures.Future):
+        super().__init__()
+        self._wrapped_future = wrapped_future
+
+        def callback(f):
+            try:
+                self.set_result(f.result())
+            except Exception as e:
+                logging.info("Background precompilation failed (fallback to JIT at runtime): %s", e)
+                # Resolve to None without throwing an exception.
+                self.set_result(None)
+
+        self._wrapped_future.add_done_callback(callback)
+
+    def cancel(self):
+        """Cancel the wrapped future."""
+        # We must cancel the inner future, and depending on success, cancel ourselves.
+        if self._wrapped_future.cancel():
+            return super().cancel()
+        return False

--- a/src/mbi/_future.py
+++ b/src/mbi/_future.py
@@ -10,6 +10,7 @@ class RobustFuture(concurrent.futures.Future):
   """
 
   def __init__(self, wrapped_future: concurrent.futures.Future):
+    """Initialize a RobustFuture wrapping another future."""
     super().__init__()
     self._wrapped_future = wrapped_future
 

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -14,6 +14,7 @@ Pull requests are welcome to add support for other approximate oracles.
 
 from __future__ import annotations
 
+import concurrent.futures
 import functools
 import itertools
 from collections.abc import Sequence
@@ -24,6 +25,8 @@ import jax
 import jax.numpy as jnp
 import networkx as nx
 from scipy.cluster.hierarchy import DisjointSet
+
+_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
 from . import estimation
 from . import marginal_loss
@@ -375,7 +378,7 @@ class ApproxMirrorDescent:
       measurements: list[LinearMeasurement] | None = None,
       *,
       extra_cliques: list[tuple[str, ...]] | None = None,
-  ) -> None:
+  ) -> concurrent.futures.Future:
     """Warm up the JIT cache for ``estimate``.
 
     Args:
@@ -400,7 +403,9 @@ class ApproxMirrorDescent:
     abstract_state = jax.eval_shape(self._init, potentials, 1.0)
 
     # lower().compile() populates the jit cache without executing.
-    self._step.lower(self, abstract_state, 1.0, loss_fn).compile()
+    lowered = self._step.lower(self, abstract_state, 1.0, loss_fn)
+    from ._future import RobustFuture
+    return RobustFuture(_COMPILE_POOL.submit(lowered.compile))
 
 
 def mirror_descent(

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -15,28 +15,28 @@ Pull requests are welcome to add support for other approximate oracles.
 from __future__ import annotations
 
 import concurrent.futures
+import dataclasses
 import functools
 import itertools
 from collections.abc import Sequence
 from typing import Any, NamedTuple, Protocol
 
-import dataclasses
 import jax
 import jax.numpy as jnp
 import networkx as nx
 from scipy.cluster.hierarchy import DisjointSet
 
-_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
+from . import estimation, marginal_loss
 from ._future import RobustFuture
-from . import estimation
-from . import marginal_loss
 from .clique_utils import Clique
 from .clique_vector import CliqueVector
 from .domain import Domain
 from .factor import Factor
 from .marginal_loss import LinearMeasurement
 
+
+_COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 # pylint: disable
 
 

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -28,6 +28,7 @@ from scipy.cluster.hierarchy import DisjointSet
 
 _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
+from ._future import RobustFuture
 from . import estimation
 from . import marginal_loss
 from .clique_utils import Clique
@@ -404,7 +405,7 @@ class ApproxMirrorDescent:
 
     # lower().compile() populates the jit cache without executing.
     lowered = self._step.lower(self, abstract_state, 1.0, loss_fn)
-    from ._future import RobustFuture
+
     return RobustFuture(_COMPILE_POOL.submit(lowered.compile))
 
 

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -22,6 +22,7 @@ import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, cast
+from ._future import RobustFuture
 
 import dataclasses
 import jax
@@ -249,7 +250,7 @@ class Estimator(ABC):
     lowered = self._multi_step.lower(
         self, abstract_state, loss_fn, 1.0, abstract_constraints
     )
-    from ._future import RobustFuture
+
     return RobustFuture(_COMPILE_POOL.submit(lowered.compile))
 
 

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -249,7 +249,8 @@ class Estimator(ABC):
     lowered = self._multi_step.lower(
         self, abstract_state, loss_fn, 1.0, abstract_constraints
     )
-    return _COMPILE_POOL.submit(lowered.compile)
+    from ._future import RobustFuture
+    return RobustFuture(_COMPILE_POOL.submit(lowered.compile))
 
 
 def minimum_variance_unbiased_total(

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -16,15 +16,13 @@ support the cliques of the marginal-based loss function can be used here.
 from __future__ import annotations
 
 import concurrent.futures
+import dataclasses
 import functools
 import math
-
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, cast
-from ._future import RobustFuture
 
-import dataclasses
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -32,7 +30,13 @@ import optax
 from jax.typing import ArrayLike
 
 from . import marginal_loss, marginal_oracles
-from ._api import Model, Projectable  # noqa: F401  # pylint: disable=unused-import
+# pylint: disable=unused-import
+from ._api import (
+    Model,  # noqa: F401
+    Projectable,  # noqa: F401
+)
+# pylint: enable=unused-import
+from ._future import RobustFuture
 from .clique_vector import CliqueVector
 from .constraint import Constraint
 from .domain import Domain

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -10,19 +10,18 @@ import logging
 import time
 from collections.abc import Sequence
 from typing import Any
-from .._future import RobustFuture
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
 from .. import junction_tree, marginal_oracles
+from .._future import RobustFuture
 from ..clique_utils import Clique, clique_mapping
 from ..clique_vector import CliqueVector
 from ..constraint import Constraint
 from ..dataset import Dataset
-from ..domain import Attribute
-from ..domain import Domain
+from ..domain import Attribute, Domain
 from ..factor import Factor
 from ..markov_random_field import MarkovRandomField
 
@@ -113,7 +112,6 @@ def precompile(
           parent_sizes=cp.parent_sizes,
           total=rows,
       ).compile()
-
 
   return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -113,7 +113,8 @@ def precompile(
           total=rows,
       ).compile()
 
-  return _COMPILE_POOL.submit(_compile_all)
+  from .._future import RobustFuture
+  return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 
 
 def synthetic_data(

--- a/src/mbi/extensions/synthetic_data.py
+++ b/src/mbi/extensions/synthetic_data.py
@@ -10,6 +10,7 @@ import logging
 import time
 from collections.abc import Sequence
 from typing import Any
+from .._future import RobustFuture
 
 import jax
 import jax.numpy as jnp
@@ -113,7 +114,7 @@ def precompile(
           total=rows,
       ).compile()
 
-  from .._future import RobustFuture
+
   return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -25,13 +25,13 @@ import string
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Protocol
-from ._future import RobustFuture
 
 import jax
 import jax.numpy as jnp
 import networkx as nx
 
 from . import junction_tree
+from ._future import RobustFuture
 from .clique_utils import Clique, clique_mapping
 from .clique_vector import CliqueVector
 from .constraint import Constraint
@@ -703,7 +703,6 @@ def precompile_bulk_variable_elimination(
           total=1.0,
           constraints=abstract_constraints,
       ).compile()
-
 
   return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -25,6 +25,7 @@ import string
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Protocol
+from ._future import RobustFuture
 
 import jax
 import jax.numpy as jnp
@@ -703,7 +704,7 @@ def precompile_bulk_variable_elimination(
           constraints=abstract_constraints,
       ).compile()
 
-  from ._future import RobustFuture
+
   return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 
 

--- a/src/mbi/marginal_oracles.py
+++ b/src/mbi/marginal_oracles.py
@@ -703,7 +703,8 @@ def precompile_bulk_variable_elimination(
           constraints=abstract_constraints,
       ).compile()
 
-  return _COMPILE_POOL.submit(_compile_all)
+  from ._future import RobustFuture
+  return RobustFuture(_COMPILE_POOL.submit(_compile_all))
 
 
 def bulk_variable_elimination(


### PR DESCRIPTION
Updates all `precompile` methods across `mbi` to return a `RobustFuture`, which intercepts and logs any exceptions that happen during XLA lowering/compilation in the background without raising them on `.result()`. This simplifies the downstream caller code.