### PR TITLE
Deprecate passing single string/int to project()

### DIFF
--- a/src/mbi/clique_vector.py
+++ b/src/mbi/clique_vector.py
@@ -9,18 +9,18 @@ and performing arithmetic operations on these collections.
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import operator
 import warnings
 from collections.abc import Sequence
 
-import dataclasses
-from jax.typing import ArrayLike
 import jax
 import jax.numpy as jnp
+from jax.typing import ArrayLike
 
 from .clique_utils import Clique, reverse_clique_mapping
-from .domain import Domain
+from .domain import Attribute, Domain
 from .factor import Factor, Projectable
 
 
@@ -109,11 +109,18 @@ class CliqueVector:
       return None
     return min(candidates, key=self.domain.size)
 
-  def supports(self, clique: Clique) -> bool:
+  def supports(self, clique: Attribute | Sequence[Attribute]) -> bool:
     """Checks if the given clique is supported (is a subset of any clique in the vector)."""
+    if isinstance(clique, (str, int)):
+      clique = (clique,)
+    clique = tuple(clique)
     return self.parent(clique) is not None
 
-  def project(self, clique: Clique, log: bool = False) -> Factor:
+  def project(
+      self, clique: Attribute | Sequence[Attribute], log: bool = False
+  ) -> Factor:
+    if isinstance(clique, (str, int)):
+      clique = (clique,)
     clique = tuple(clique)
     if clique in self.tables:
       return self[clique]

--- a/src/mbi/extensions/mixture_of_products.py
+++ b/src/mbi/extensions/mixture_of_products.py
@@ -11,7 +11,8 @@ This is a cleaned-up, optimized replacement for
 
 from __future__ import annotations
 
-
+import dataclasses
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import NamedTuple
 
@@ -21,13 +22,10 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 
-import dataclasses
-
-
-from ..estimation import Estimator
 from ..clique_vector import CliqueVector
 from ..dataset import Dataset
 from ..domain import Attribute, Domain
+from ..estimation import Estimator
 from ..factor import Factor
 
 
@@ -71,9 +69,9 @@ class MixtureOfProducts:
         col: jax.nn.softmax(self._logits[col], axis=1) for col in self._logits
     }
 
-  def project(self, attrs) -> Factor:
+  def project(self, attrs: Attribute | Sequence[Attribute]) -> Factor:
     """Compute the marginal over ``attrs`` via einsum."""
-    if isinstance(attrs, str):
+    if isinstance(attrs, (str, int)):
       attrs = (attrs,)
     attrs = tuple(attrs)
     d = len(attrs)
@@ -84,9 +82,9 @@ class MixtureOfProducts:
     values = jnp.einsum(formula, *components) * self.total / self.num_components
     return Factor(self.domain.project(attrs), values)
 
-  def supports(self, attrs) -> bool:
+  def supports(self, attrs: Attribute | Sequence[Attribute]) -> bool:
     """Any subset of domain attributes is supported."""
-    if isinstance(attrs, str):
+    if isinstance(attrs, (str, int)):
       attrs = (attrs,)
     return all(a in self.domain.attributes for a in attrs)
 


### PR DESCRIPTION
This PR adds a  alert across all  classes (like , , , , ) when a single string or integer is passed to the  method. Users should pass a tuple/sequence instead (e.g., `(col,)`). This unblocks future refactors to the `Projectable` interface signature.