### PR TITLE
fix: avoid in-place update in synthetic_data generation

### DIFF
--- a/mechanisms/cdp2adp.py
+++ b/mechanisms/cdp2adp.py
@@ -22,7 +22,6 @@ limitations under the License.
 import math
 import matplotlib.pyplot as plt
 
-
 # *********************************************************************
 # Now we move on to concentrated DP
 

--- a/mechanisms/mechanism.py
+++ b/mechanisms/mechanism.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 # from autodp import privacy_calibrator
 from functools import partial
 import os as _os

--- a/mechanisms/mwem+pgm.py
+++ b/mechanisms/mwem+pgm.py
@@ -12,7 +12,6 @@ _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
 from cdp2adp import cdp_rho
 import argparse
 
-
 """
 This file contains an implementation of MWEM+PGM that is designed specifically for marginal query workloads.
 Unlike mwem.py, which selects a single query in each round, this implementation selects an entire marginal 

--- a/src/mbi/approximate_oracles.py
+++ b/src/mbi/approximate_oracles.py
@@ -35,7 +35,6 @@ from .domain import Domain
 from .factor import Factor
 from .marginal_loss import LinearMeasurement
 
-
 _COMPILE_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 # pylint: disable
 

--- a/src/mbi/estimation.py
+++ b/src/mbi/estimation.py
@@ -30,11 +30,13 @@ import optax
 from jax.typing import ArrayLike
 
 from . import marginal_loss, marginal_oracles
+
 # pylint: disable=unused-import
 from ._api import (
     Model,  # noqa: F401
     Projectable,  # noqa: F401
 )
+
 # pylint: enable=unused-import
 from ._future import RobustFuture
 from .clique_vector import CliqueVector

--- a/src/mbi/markov_random_field.py
+++ b/src/mbi/markov_random_field.py
@@ -112,7 +112,7 @@ class MarkovRandomField:
       if method == "sample":
         probas = counts / counts.sum()
         return np.random.choice(options, total, True, probas)
-      counts *= total / counts.sum()
+      counts = counts * (total / counts.sum())
       frac, integ = np.modf(counts)
       integ = integ.astype(int)
       extra = total - integ.sum()

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -17,7 +17,6 @@ from mbi.extensions.message_passing import shafer_shenoy as ext_shafer_shenoy
 from mbi.marginal_oracles import message_passing_shafer_shenoy
 from parameterized import parameterized
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -48,6 +48,7 @@ from mbi import (
     marginal_loss,
     marginal_oracles,
 )
+
 # ``mbi.extensions.__init__`` re-exports the ``synthetic_data`` *function*, which
 # shadows the submodule of the same name under normal ``import ... as`` (that
 # resolves via the parent package attribute). Fetch the module object directly so

--- a/test/test_reweighted_dataset.py
+++ b/test/test_reweighted_dataset.py
@@ -14,7 +14,6 @@ from mbi.dataset import Dataset, JaxDataset
 from mbi.extensions.reweighted_dataset import ReweightedDatasetEstimator
 from mbi.factor import Factor
 
-
 np.random.seed(42)  # Avoid flaky tests
 
 


### PR DESCRIPTION
Converts the in-place `counts *= ...` update in `synthetic_col` to a re-assignment `counts = counts * ...` to prevent side-effects on read-only buffers or referenced arrays.